### PR TITLE
merge in branch before develop / master

### DIFF
--- a/commands/git-finish
+++ b/commands/git-finish
@@ -29,18 +29,38 @@ if [[ $BRANCH = 'master' || $BRANCH = 'develop' ]]; then
   exit 255
 fi
 
+if [[ $DEVELOP_EXISTS -eq 0 ]]; then
+  git checkout develop
+  git pull origin develop
+fi
+
 if [[ $TYPE = 'hotfix' || ${BRANCH:0:7} = "hotfix/" || $DEVELOP_EXISTS -ne 0 ]]; then
   git checkout master
   git pull origin master
-  git merge --no-ff $BRANCH
-  [[ $1 = 'push' || $2 = 'push' ]] && git push origin master
+fi
+
+git checkout $BRANCH
+
+if [[ $DEVELOP_EXISTS -eq 0 ]]; then
+  git merge --no-ff develop
+fi
+
+if [[ $TYPE = 'hotfix' || ${BRANCH:0:7} = "hotfix/" || $DEVELOP_EXISTS -ne 0 ]]; then
+  git merge --no-ff master
 fi
 
 if [[ $DEVELOP_EXISTS -eq 0 ]]; then
   git checkout develop
-  git pull origin develop
+  git pull origin develop # be extra sure we have up to date branches
   git merge --no-ff $BRANCH
   [[ $1 = 'push' || $2 = 'push' ]] && git push origin develop
+fi
+
+if [[ $TYPE = 'hotfix' || ${BRANCH:0:7} = "hotfix/" || $DEVELOP_EXISTS -ne 0 ]]; then
+  git checkout master
+  git pull origin master # be extra sure we have up to date branches
+  git merge --no-ff $BRANCH
+  [[ $1 = 'push' || $2 = 'push' ]] && git push origin master
 fi
 
 git branch -d $BRANCH                   # deletes local branch


### PR DESCRIPTION
i'm proposing we consider switching to a different flow for git finish.

right now, we just checkout master, pull, and merge our working branch in. this could be somewhat problematic if there are conflicts. it would force us to resolve conflicts and finish the merge manually in master (or develop). if the conflicts are messy, this could potentially lead to buggy code getting committed to master.

i'm suggesting that git finish first checkout and pull on both develop and master, then perform the merge in the current working branch. this way, if someone runs into merge conflicts, they can resolve them and test them in their own branch, rather than develop or master. after merging in the working branch, it would then checkout develop / master, pull again (just to be sure), and merge the working branch. unless something crazy happens, this should prevent us from having to resolve conflicts in master or develop.

let me know what you think.
