### PR TITLE
Update README now that type branches and develop are no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,70 +25,41 @@ Run **git plus upgrade** to easily pull the latest of this repo's origin/master 
 
 #### git start
 
-Sort of like "flow <type> start <name>", but slightly different just to be confusing.
-
-Starts a `type/name` branch, usually a feature or hotfix, and starts from the correct starting branch for you.
+Starts a branch.
 
 ```shell
-# start a hotfix (off of master by default)
-$ git start hotfix FAD-1234
+# start a branch (off master by default)
+$ git start FAD-1234
 
-# start a feature (off of develop by default)
-$ git start feature FAD-1234
-
-# start whateveryouwant off of a specified branch
-$ git start whatever FAD-1234 master
+# start a branch off master, as specified
+$ git start FAD-1234 master
 ```
 
 #### git finish
 
-Does a --no-ff merge to master (if hotfix) and develop. Will also work in repos that don't have a develop
-branch by merging to master by default.
+Does a --no-ff merge to master.
 
 Specify "push" as the last argument to auto-push merged branch(es).
 
 ```shell
-# Merge hotfix/FAD-1234 to master and develop
+# Merge FAD-1234 to master
 $ git finish
 
-# Merge feature/FAD-1234 to develop only
-$ git finish
-
-# Merge feature or hotfix and push merged branch(es) to origin
+# Merge to master and push merged branch to origin
 $ git finish push
-
-# Merge whatever/FAD-1234 to master and develop (specify type is hotfix)
-$ git finish hotfix
-
-# Merge other branch and push merged branch(es) to origin
-$ git finish hotfix push
-```
-
-#### git promote
-
-Merges develop into master locally, using a --no-ff merge to create an explicit merge commit.
-
-Specify "push" as the last argument to auto-push master after merge.
-
-```shell
-# Merge develop to master
-$ git promote
-
-# Also push master to origin
-$ git promote push
 ```
 
 #### git update
 
-Merges master or develop into your current branch depending on your branch type and if there is a develop branch available.  It will also merge master into develop if on the develop branch.
+Merges master into your current branch.
 
 Specify "rebase" to rebase the changes rather than merge them.
 
 ```shell
-# Merge develop or master into your branch
+# Merge master into your branch
 $ git update
 
-# Rebase develop or master into your branch
+# Rebase master into your branch
 $ git update rebase
 ```
 


### PR DESCRIPTION
#7 removed support for develop branches, but the README documentation was not updated. Update it.